### PR TITLE
Feat: Top、About、Privacy Policy、Terms of Service の各静的ページを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
+# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 6.1.7", ">= 6.1.7.10"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "~> 1.4"
@@ -18,9 +18,9 @@ gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.7"
 # Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
+# gem "redis", "~> 4.0"
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# gem "bcrypt", "~> 3.1.7"
 
 # Use Active Storage variant
 gem "image_processing", "~> 1.2"
@@ -29,7 +29,7 @@ gem "image_processing", "~> 1.2"
 gem "bootsnap", ">= 1.4.4", require: false
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
 
   # 開発/テスト用ダミーデータ作成
@@ -37,7 +37,7 @@ group :development, :test do
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  # Access an interactive console on exception pages or by calling "console" anywhere in the code.
   gem "web-console", ">= 4.1.0"
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
@@ -67,7 +67,7 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # ユーザー認証機能
-gem 'devise'
+gem "devise"
 
 # ページネーション
 gem "kaminari", "~> 1.2.1"

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,5 +1,9 @@
 class Public::HomesController < ApplicationController
   def top
+    # 新着投稿8件（投稿日時が新しい順）
+    @new_posts = Post.order(created_at: :desc).limit(8)
+    # 人気コミュニティグループ3件（メンバー数が多い順）
+    @popular_communities = Community.left_joins(:community_members).group(:id).order('COUNT(community_members.id) DESC').limit(3)
   end
 
   def about

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -11,9 +11,9 @@
             メールアドレスとパスワードを入力してください
           </h5>
 
-          <%= render 'layouts/error_messages', resource: resource %>
+          <%= render "public/shared/error_messages", resource: resource %>
 
-          <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <%= form_with scope: resource_name, url: session_path(resource_name), local: true do |f| %>
             <div class="form-group">
               <%= f.email_field :email, class:"form-control", autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
             </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav class="navbar navbar-expand-md navbar-light bg-light">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container">
 
       <%= link_to root_path, class: "navbar-brand" do %>
@@ -14,7 +14,7 @@
       <div class="collapse navbar-collapse" id="navbarNav">
       <% if user_signed_in? %>
         <span class="navbar-text ml-5">
-          ようこそ、<%= current_user.name %>さん！
+          ようこそ、<strong><%= current_user.name %></strong> さん！
         </span>
       <% end %>
         <ul class="navbar-nav ml-auto">

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,2 +1,77 @@
-<h1>Public::Homes#about</h1>
-<p>Find me in app/views/public/homes/about.html.erb</p>
+<div class="container mt-5 mb-5">
+  <div class="row align-items-center justify-content-center">
+    <div class="col-lg-12 mb-4 mx-auto text-center">
+      <h2 class="display-4 text-dark font-weight-bold mt-1 mb-1 pb-5">
+        <i class="fa-solid fa-motorcycle mr-3 text-primary"></i>Toulink (つーりんく) について
+      </h2>
+
+      <p class="lead text-secondary">
+        Toulink（つーりんく）は、<span class="font-weight-bold text-dark">ツーリング仲間を探したり、イベントを企画・参加できる</span><br>
+        バイク好きのためのコミュニティプラットフォームです。
+      </p>
+
+      <p class="text-muted">
+        「<span class="font-weight-bold text-dark">安心できる仲間と、最高の旅路を。</span>」をコンセプトに、<br>
+        同じ価値観を持つライダー同士がつながり、ツーリングの企画や情報共有を安全かつスムーズに行える場所を提供します。
+      </p>
+
+      <p class="text-muted small">
+        バイクは好きでも、相性の良いツーリング仲間を見つけるのは意外と難しいもの。<br>
+        初心者やリターンライダーにも利用しやすい、安心感のある交流環境を目指しています。
+      </p>
+    </div>
+  </div>
+
+  <hr class="my-5">
+
+  <h3 class="text-center mb-5 text-dark">「つーりんく」の３つの魅力</h3>
+
+  <div class="row">
+    <div class="col-md-4 mb-4">
+      <div class="card shadow-sm h-100 border-primary">
+        <div class="card-body text-center">
+          <i class="fa-solid fa-route fa-3x text-primary mb-3"></i>
+          <h5 class="card-title font-weight-bold">ツーリングの記録と発見</h5>
+          <p class="card-text small text-muted">
+            ユーザーは、ツーリングで立ち寄ったスポットを投稿できます。<br>
+            絶景ポイントやライダーズスポットの共有を通して、新しい旅のきっかけが広がります。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4 mb-4">
+      <div class="card shadow-sm h-100 border-success">
+        <div class="card-body text-center">
+          <i class="fa-solid fa-link fa-3x text-success mb-3"></i>
+          <h5 class="card-title font-weight-bold">仲間と繋がるコミュニティ</h5>
+          <p class="card-text small text-muted">
+            同じ価値観を持つライダーとつながり、交流や情報交換ができます。<br>
+            気になるユーザーのフォローや、コミュニティ参加で輪が広がります。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4 mb-4">
+      <div class="card shadow-sm h-100 border-info">
+        <div class="card-body text-center">
+          <i class="fa-solid fa-circle-info fa-3x text-info mb-3"></i>
+          <h5 class="card-title font-weight-bold">安全で快適な旅を支える情報</h5>
+          <p class="card-text small text-muted">
+            地図情報、タグ検索、立ち寄りスポットの情報など、<br>
+            ツーリングをより安心かつ快適にするための情報を共有できます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <hr class="my-5">
+
+  <div class="text-center mt-5">
+    <p class="lead">
+      さぁ、あなたの <span class="font-weight-bold text-dark">つーりんく</span> を、始めましょう。
+    </p>
+  </div>
+</div>

--- a/app/views/public/homes/privacy_policy.html.erb
+++ b/app/views/public/homes/privacy_policy.html.erb
@@ -1,2 +1,142 @@
-<h1>Public::Homes#privacy_policy</h1>
-<p>Find me in app/views/public/homes/privacy_policy.html.erb</p>
+<div class="container mt-5 mb-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+      
+      <h2 class="display-4 text-dark font-weight-bold mb-4 pb-2 text-center">
+        <i class="fa-solid fa-user-lock mr-3 text-secondary"></i>プライバシーポリシー
+      </h2>
+
+      <p class="lead text-center text-muted mb-5">
+        Toulink（つーりんく）は、お客様の個人情報の重要性を認識し、その保護を徹底します。
+      </p>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          1. 個人情報の定義と適用範囲
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            本ポリシーにおける「個人情報」とは、氏名、メールアドレス、パスワード、その他特定の個人を識別できる情報を指します。本ポリシーは、本サービス（Toulink）内で収集される全ての個人情報に適用されます。
+          </p>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          2. 取得する情報とその利用目的
+        </div>
+        <div class="card-body">
+          <p class="card-title font-weight-bold">（1）ユーザー登録時に取得する情報</p>
+          <div class="row justify-content-center">
+            <div class="col-md-11">
+              <div class="table-responsive mb-4">
+                <table class="table table-bordered table-sm small">
+                  <thead class="thead-light">
+                    <tr>
+                      <th scope="col" style="width: 20%;">取得情報</th>
+                      <th scope="col">利用目的</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="font-weight-bold">ユーザー名</td>
+                      <td>サービス内での識別、コミュニティ活動における表示名として利用します。</td>
+                    </tr>
+                    <tr>
+                      <td class="font-weight-bold">メールアドレス</td>
+                      <td>本人確認、パスワードリセット、サービスからのお知らせ（重要連絡含む）に利用します。</td>
+                    </tr>
+                    <tr>
+                      <td class="font-weight-bold">パスワード</td>
+                      <td>ユーザー認証およびセキュリティのために利用します。</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <p class="card-title font-weight-bold mt-4">（2）サービス利用時に取得する情報</p>
+          <div class="row justify-content-center">
+            <div class="col-md-11">
+              <div class="table-responsive">
+                <table class="table table-bordered table-sm small">
+                  <thead class="thead-light">
+                    <tr>
+                      <th scope="col" style="width: 20%;">取得情報</th>
+                      <th scope="col">利用目的</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="font-weight-bold">投稿情報</td>
+                      <td>投稿内容、画像データ、タグ情報、ルート情報など。<br>これらは本サービスを構成するコンテンツとして、他のユーザーに公開されます。</td>
+                    </tr>
+                    <tr>
+                      <td class="font-weight-bold">位置情報</td>
+                      <td>ツーリングルート情報として任意で取得・公開されることがあります。</td>
+                    </tr>
+                    <tr>
+                      <td class="font-weight-bold">Cookie情報</td>
+                      <td>アクセス解析やサービス利便性向上、広告配信のために利用します。</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          3. 個人情報の第三者への提供
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            当社は、法令に基づく場合、またはご本人様の同意がある場合を除き、個人情報を第三者（他のユーザーを含む）に提供することはありません。<br>
+            ただし、本サービスの機能上、<strong>投稿内容、ユーザー名、プロフィール写真、その他のコミュニティ活動に関する情報は他のユーザーに公開されます</strong>。
+          </p>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          4. 個人情報の安全管理
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            当社は、個人情報の漏洩、滅失、毀損などを防止するため、適切な安全管理措置を講じます。
+          </p>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          5. 個人情報の開示・訂正・削除
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            ご本人様から個人情報の開示、訂正、削除の請求があった場合、ご本人確認を行った上で、法令に従い速やかに対応いたします。
+          </p>
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          6. お問い合わせ窓口
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            本ポリシーに関するお問い合わせは、以下の連絡先までお願いいたします。<br>
+            <span>連絡先メールアドレス：<strong>zeyoru243@quicksend.ch</strong></span> 
+          </p>
+        </div>
+      </div>
+      
+      <p class="text-right small text-muted mt-5">
+        制定日: 2025年11月1日
+      </p>
+
+    </div>
+  </div>
+</div>

--- a/app/views/public/homes/terms_of_service.html.erb
+++ b/app/views/public/homes/terms_of_service.html.erb
@@ -1,2 +1,111 @@
-<h1>Public::Homes#terms_of_service</h1>
-<p>Find me in app/views/public/homes/terms_of_service.html.erb</p>
+<div class="container mt-5 mb-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+
+      <h2 class="display-4 text-dark font-weight-bold mb-4 pb-2 text-center">
+        <i class="fas fa-file-contract mr-3 text-warning"></i>Toulink 利用規約
+      </h2>
+
+      <p class="lead text-center text-muted mb-5">
+        本規約は、Toulink（つーりんく）の利用に関する条件を定めるものです。<br>
+        サービス利用前に必ずお読みください。
+      </p>
+
+      <%# --- 第1条：適用範囲 --- %>
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          第1条（本規約の適用）
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            本規約は、本サービスを利用する全てのユーザーと当サービス運営者との間に適用されます。ユーザーは、本サービスの利用をもって本規約に同意したものとみなされます。
+          </p>
+        </div>
+      </div>
+
+      <%# --- 第2条：定義 --- %>
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          第2条（ユーザー登録とアカウント管理）
+        </div>
+        <div class="card-body">
+          <ul class="list-unstyled mb-0 small">
+            <li><i class="fas fa-angle-right text-secondary mr-2"></i>ユーザーは、自己の責任においてアカウント情報を管理するものとし、第三者に利用させたり、貸与、譲渡することはできません。</li>
+            <li><i class="fas fa-angle-right text-secondary mr-2"></i>未成年者は、親権者または法定代理人の同意を得て本サービスを利用するものとします。</li>
+          </ul>
+        </div>
+      </div>
+
+      <%# --- 第3条：サービス内容 --- %>
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          第3条（本サービスの内容）
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            本サービスは、バイクツーリングに関する情報（ルート、スポット、イベント）の共有、ユーザー間の交流、およびツーリング募集を目的として提供されます。
+          </p>
+        </div>
+      </div>
+
+      <%# --- 第4条：投稿コンテンツ --- %>
+      <div class="card shadow-sm mb-4 border-secondary">
+        <div class="card-header bg-secondary text-white font-weight-bold">
+          第4条（投稿コンテンツの権利）
+        </div>
+        <div class="card-body">
+          <p class="card-text">
+            ユーザーが投稿したコンテンツ（写真、文章、ルート情報等）の著作権は、当該ユーザーに留保されます。<br>
+            ただし、ユーザーは運営者に対し、本サービスの運営およびプロモーションに必要な範囲内での利用（複製、公開、改変等）を無償で許諾するものとします。
+          </p>
+        </div>
+      </div>
+
+      <%# --- 第5条：禁止事項 (重要) --- %>
+      <div class="card shadow-sm mb-4 border-danger">
+        <div class="card-header bg-danger text-white font-weight-bold">
+          第5条（禁止事項）
+        </div>
+        <div class="card-body">
+          <p class="card-text font-weight-bold">
+            ユーザーは、本サービスの利用にあたり、以下の行為を行ってはならないものとします。
+          </p>
+          <ul class="list-unstyled mb-0 small">
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i>法令、公序良俗に反する行為、またはその恐れのある行為。</li>
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i>他のユーザー、第三者、または運営者の著作権、プライバシー権、その他の権利を侵害する行為。</li>
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i>過度な誹謗中傷、差別的表現、またはハラスメント行為。</li>
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i><strong>危険な運転、法令違反となるルートの推奨や投稿</strong>。</li>
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i>営業、広告宣伝目的の行為（運営者が認めた場合を除く）。</li>
+            <li><i class="fa-solid fa-circle-xmark text-danger mr-2"></i>虚偽の情報を登録、投稿する行為。</li>
+          </ul>
+        </div>
+      </div>
+
+      <%# --- 第6条：免責事項 (重要) --- %>
+      <div class="card shadow-sm mb-5 border-danger">
+        <div class="card-header bg-danger text-white font-weight-bold">
+          第6条（免責事項）
+        </div>
+        <div class="card-body">
+          <ul class="list-unstyled mb-0 small">
+            <li><i class="fa-solid fa-triangle-exclamation text-warning mr-2"></i>本サービスは情報共有の場であり、<strong>ツーリングの企画、参加、実施に関する事故、損害、トラブル等について、運営者は一切の責任を負いません</strong>。全て自己責任で行動するものとします。</li>
+            <li><i class="fa-solid fa-triangle-exclamation text-warning mr-2"></i>本サービス上に掲載された情報（ルート、スポット、募集情報など）の正確性、完全性、有用性について、運営者は一切保証しません。</li>
+          </ul>
+        </div>
+      </div>
+
+      <%# --- 問い合わせ先 --- %>
+      <div class="card shadow-sm mb-4">
+        <div class="card-header font-weight-bold">
+          附則
+        </div>
+        <div class="card-body">
+          <p class="card-text small">
+            本規約は、2025年11月14日から適用されるものとします。本規約は、運営者の判断により、ユーザーの承諾なく変更されることがあります。
+          </p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,2 +1,73 @@
-<h1>Public::Homes#top</h1>
-<p>Find me in app/views/public/homes/top.html.erb</p>
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-lg-9">
+      <h3 class="mt-5 mb-4 border-bottom pb-2 text-success font-weight-bold">
+        <i class="fa-solid fa-people-robbery mr-2"></i>人気コミュニティ（Popular Communities）
+      </h3>
+
+      <div class="row">
+        <% @popular_communities.each do |community| %>
+          <div class="col-md-6 col-lg-3 mb-4">
+            <div class="card shadow-sm h-100">
+              <%# 仮リンク %>
+              <%= link_to "#", class: "text-decoration-none text-dark" do %>
+                <div class="card-body p-2 text-center">
+                  <h5 class="card-title font-weight-bold text-success mb-1 small"><%= truncate(community.name, length: 20) %></h5>
+                  <p class="card-text text-muted small"><%= community.community_members.count %> メンバー</p>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <h3 class="mb-4 border-bottom pb-2 text-primary font-weight-bold">
+        <i class="fa-regular fa-clipboard mr-2"></i>新着投稿（New Posts）
+      </h3>
+
+      <div class="row">
+        <% @new_posts.each do |post| %>
+          <div class="col-md-6 col-lg-3 mb-4">
+            <div class="card shadow-sm h-100">
+              <%# 仮リンク %>
+              <%= link_to "#", class: "text-decoration-none text-dark" do %>
+                <div class="card-img-top bg-light text-center p-3" style="height: 150px;">
+                </div>
+                <div class="card-body p-2">
+                  <p class="card-title font-weight-bold mb-1 small"><%= truncate(post.title, length: 25) %></p>
+                  <p class="card-text text-muted small mb-0">by <%= post.user.name %></p>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="col-lg-3">
+      <div class="card shadow-sm p-3 sticky-top" style="top: 20px;">
+        <h5 class="font-weight-bold pb-2">メニュー（仮）</h5>
+        <div class="list-group list-group-flush small">
+          <% if current_user %>
+            <%# 仮リンク %>
+            <%= link_to "#", class: 'list-group-item list-group-item-action' do %>
+              <i class="fa-solid fa-id-card mr-2"></i>マイページへ
+            <% end %>
+          <% end %>
+          <%# 仮リンク %>
+          <%= link_to "#", class: 'list-group-item list-group-item-action' do %>
+            <i class="fa-solid fa-users mr-2"></i>会員一覧を見る
+          <% end %>
+          <%# 仮リンク %>
+          <%= link_to "#", class: 'list-group-item list-group-item-action' do %>
+            <i class="fa-regular fa-clipboard mr-2"></i>投稿一覧を見る
+          <% end %>
+          <%# 仮リンク %>
+          <%= link_to "#", class: 'list-group-item list-group-item-action' do %>
+            <i class="fa-solid fa-earth-asia mr-2"></i>コミュニティを見る
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -13,7 +13,7 @@
 
           <%= render "public/shared/error_messages", resource: resource %>
 
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= form_with scope: resource_name, url: registration_path(resource_name), local: true do |f| %>
             <div class="form-group">
               <%= f.label :name, "ユーザー名" %>
               <%= f.text_field :name, class:"form-control", autofocus: true, placeholder: "ユーザー名" %>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -11,9 +11,9 @@
             メールアドレスとパスワードを入力してください
           </h5>
 
-          <%= render 'layouts/error_messages', resource: resource %>
+          <%= render "public/shared/error_messages", resource: resource %>
 
-          <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <%= form_with scope: resource_name, url: session_path(resource_name), local: true do |f| %>
             <div class="form-group">
               <%= f.email_field :email, class:"form-control", autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
             </div>

--- a/db/migrate/20251114073343_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20251114073343_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,48 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_11_11_074831) do
+ActiveRecord::Schema.define(version: 2025_11_14_073343) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -125,6 +154,8 @@ ActiveRecord::Schema.define(version: 2025_11_11_074831) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "communities", "users", column: "owner_id"


### PR DESCRIPTION
## 概要
以下の 4 つの静的ページを新規実装しました。

- Top（トップページ）
- About（サイト説明ページ）
- Privacy Policy（プライバシーポリシー）
- Terms of Service（利用規約）

ユーザーがサイトの基本情報にアクセスできるよう、最低限のレイアウト構成を整えています。

## 変更内容
- `PagesController` を作成し、必要なアクション（top / about / privacy_policy / terms_of_service）を追加
- 各ページに対応するビューを作成
- ルーティングを追加し、`root` をトップページへ設定
- `header`・`footer` から各ページへ遷移できるリンクを追加（必要に応じて）

## 動作確認
- 各ページへ正常にアクセスできることを確認
- レイアウトが崩れずヘッダー・フッターと連動していることを確認
- 文言が正しく表示されていることを確認

## 今後の対応
- 各ページのデザイン調整（Bootstrap に合わせた装飾）
- 文言の精査、正式版文章への差し替え
- 他の静的ページやナビゲーションの整理

ご確認よろしくお願いいたします。